### PR TITLE
Change event group members and EventOccurrences

### DIFF
--- a/backend/chore_tracker/models.py
+++ b/backend/chore_tracker/models.py
@@ -33,8 +33,8 @@ class Event(models.Model):
     name = models.CharField(max_length=60)
     first_date = models.DateField()
     first_time = models.TimeField()
-    #repeat_every = models.CharField(max_length=40, null=True, blank=True)
-    repeat_every = models.IntegerField(null=True)
+    repeat_every = models.CharField(max_length=40, null=True, blank=True)
+    #repeat_every = models.IntegerField(null=True)
 
     # Relationships
     group = models.ForeignKey(Group, on_delete=models.CASCADE, related_name="events")

--- a/backend/chore_tracker/models.py
+++ b/backend/chore_tracker/models.py
@@ -33,7 +33,8 @@ class Event(models.Model):
     name = models.CharField(max_length=60)
     first_date = models.DateField()
     first_time = models.TimeField()
-    repeat_every = models.CharField(max_length=40, null=True, blank=True)
+    #repeat_every = models.CharField(max_length=40, null=True, blank=True)
+    repeat_every = models.IntegerField(null=True)
 
     # Relationships
     group = models.ForeignKey(Group, on_delete=models.CASCADE, related_name="events")
@@ -41,6 +42,18 @@ class Event(models.Model):
 
     def __str__(self):
         return self.name
+    
+
+class EventOccurrence(models.Model):
+    id = models.AutoField(primary_key=True)
+    date = models.DateField()
+    time = models.TimeField()
+
+    # Relationships
+    event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name="occurrences")
+
+    def __str__(self):
+        return self.event.name
 
 
 class Cost(models.Model):

--- a/backend/chore_tracker/urls.py
+++ b/backend/chore_tracker/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from .views import (RegisterUser, LoginView, CreateGroup, IndexView, AddUsersToGroup, ViewGroup,
-                    CreateEvent, CurrentUserView)
+                    CreateEvent, CurrentUserView, ChangeEventMembers)
 
 urlpatterns = [
     path('', IndexView.as_view(), name='index'),
@@ -11,5 +11,6 @@ urlpatterns = [
     path('group/add_users/', AddUsersToGroup.as_view(), name='add_group'),
     path('group/view/', ViewGroup.as_view(), name='view_group'),
     path('event/create/', CreateEvent.as_view(), name='create_event'),
+    path('event/change_members/', ChangeEventMembers.as_view(), name='change_event_members'),
 
 ]

--- a/backend/chore_tracker/views.py
+++ b/backend/chore_tracker/views.py
@@ -176,47 +176,57 @@ class CreateEvent(APIView):
 
     def post(self, request):
 
-        if request.method == "POST":
-            try:
-                data = json.loads(request.body)
+        try:
+            data = json.loads(request.body)
 
-                # We have to check if the group exists before trying to create the event
+            # We have to check if the group exists before trying to create the event
+            try:
+                group = Group.objects.get(id=data.get("groupId"))
+            except Group.DoesNotExist:
+                return JsonResponse(
+                    {"success": False, "message": "No such Group"}, status=400
+                )
+
+            event = Event.objects.create(
+                # ID should be created automatically
+                name=data.get("name"),
+                # Need to determine date format
+                first_date=datetime.strptime(
+                    data.get("date"), "%Y-%m-%d %H:%M:%S"
+                ).date(),
+                first_time=datetime.strptime(
+                    data.get("date"), "%Y-%m-%d %H:%M:%S"
+                ).time(),
+                # TODO: Add this in, for now its not in interface in schema.ts
+                repeat_every="",
+                group=group,
+            )
+
+            # Get assigned members and add them. This is required due to the ManyToManyField
+            memberNames = data.get("memberNames", [])
+            for username in memberNames:
                 try:
-                    group = Group.objects.get(id=data.get("groupId"))
-                except Group.DoesNotExist:
+                    user = User.objects.get(username=username)
+
+                    group_members = group.members.all()
+                    if user in group_members:
+                        event.members.add(user)
+                    else:
+                        return JsonResponse(
+                            {"success": False, "message": f"User {username} not in group"}, status=400
+                        )
+                    
+                except User.DoesNotExist:
                     return JsonResponse(
-                        {"success": False, "message": "No such Group"}, status=400
+                        {"success": False, "message": f"User {username} not found"}, status=400
                     )
 
-                event = Event.objects.create(
-                    # ID should be created automatically
-                    name=data.get("name"),
-                    # Need to determine date format
-                    first_date=datetime.strptime(
-                        data.get("date"), "%Y-%m-%d %H:%M:%S"
-                    ).date(),
-                    first_time=datetime.strptime(
-                        data.get("date"), "%Y-%m-%d %H:%M:%S"
-                    ).time(),
-                    # TODO: Add this in, for now its not in interface in schema.ts
-                    repeat_every="",
-                    group=group,
-                )
+            return JsonResponse({"success": True, "message": ""}, status=200)
 
-                # Get assigned members and add them. This is required due to the ManyToManyField
-                members = User.objects.filter(id__in=data.get("memberIds", []))
-                event.members.set(members)
-
-                return JsonResponse({"success": True, "message": ""}, status=200)
-
-            except JSONDecodeError:
-                return JsonResponse(
-                    {"success": False, "message": "Invalid JSON in request"}, status=400
-                )
-
-        return JsonResponse(
-            {"success": False, "message": "Expected POST method"}, status=405
-        )
+        except JSONDecodeError:
+            return JsonResponse(
+                {"success": False, "message": "Invalid JSON in request"}, status=400
+            )
 
 
 class CurrentUserView(APIView):

--- a/backend/chore_tracker/views.py
+++ b/backend/chore_tracker/views.py
@@ -7,7 +7,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework.exceptions import ValidationError
 from rest_framework_simplejwt.tokens import RefreshToken
-from chore_tracker.models import Group, Event
+from chore_tracker.models import Group, Event, EventOccurrence
 import datetime
 import json
 from json import JSONDecodeError
@@ -173,6 +173,7 @@ class AddUsersToGroup(APIView):
 
 
 class CreateEvent(APIView):
+    """ Create an Event """
 
     def post(self, request):
 
@@ -197,8 +198,7 @@ class CreateEvent(APIView):
                 first_time=datetime.strptime(
                     data.get("date"), "%Y-%m-%d %H:%M:%S"
                 ).time(),
-                # TODO: Add this in, for now its not in interface in schema.ts
-                repeat_every="",
+                repeat_every=data.get("repeatEvery") if "repeatEvery" in data else None,
                 group=group,
             )
 
@@ -221,6 +221,10 @@ class CreateEvent(APIView):
                     return JsonResponse(
                         {"success": False, "message": f"User {username} not found"}, status=400
                     )
+                
+            # TODO: Add an occurrence of the Event 
+            #       For recurring Events, we need to add multiple. 
+            #       Maybe we can make a new one when the date/time for previous one has passed?
 
             return JsonResponse({"success": True, "message": ""}, status=200)
 
@@ -231,6 +235,7 @@ class CreateEvent(APIView):
         
 
 class ChangeEventMembers(APIView):
+    """ Change who is assigned to an event """
 
     def post(self, request):
 

--- a/frontend/schemas/transaction.schema.ts
+++ b/frontend/schemas/transaction.schema.ts
@@ -119,7 +119,7 @@ export interface AddEventRequest {
 	name: string;
 	date: string; // Format: "%Y-%m-%d %H:%M:%S" Lmk if you want to change this -Lance
 
-	memberIds: number[];
+	memberNames: string[]; // Usernames
 
 	groupId: number;
 }

--- a/frontend/schemas/transaction.schema.ts
+++ b/frontend/schemas/transaction.schema.ts
@@ -118,7 +118,7 @@ export interface AddUsersToGroupResponse {
 export interface AddEventRequest {
 	name: string;
 	date: string; // Format: "%Y-%m-%d %H:%M:%S" Lmk if you want to change this -Lance
-	repeatEvery?: number; // Let's do this as number of days for now. If it's a single event, please omit this
+	repeatEvery?: string; // Should be in the set {"Daily", "Weekly", "Monthly"}
 
 	memberNames: string[]; // Usernames
 

--- a/frontend/schemas/transaction.schema.ts
+++ b/frontend/schemas/transaction.schema.ts
@@ -118,6 +118,7 @@ export interface AddUsersToGroupResponse {
 export interface AddEventRequest {
 	name: string;
 	date: string; // Format: "%Y-%m-%d %H:%M:%S" Lmk if you want to change this -Lance
+	repeatEvery?: number; // Let's do this as number of days for now. If it's a single event, please omit this
 
 	memberNames: string[]; // Usernames
 
@@ -133,9 +134,7 @@ export interface AddEventResponse {
 // change users assigned to event -------------------------------------------------------
 export interface ChangeEventMembersRequest {
 	name: string;
-
 	memberNames: string[]; // Usernames
-
 	groupId: number;
 }
 

--- a/frontend/schemas/transaction.schema.ts
+++ b/frontend/schemas/transaction.schema.ts
@@ -129,3 +129,19 @@ export interface AddEventResponse {
 	message: string;
 }
 // --------------------------------------------------------------------------------------
+
+// change users assigned to event -------------------------------------------------------
+export interface ChangeEventMembersRequest {
+	name: string;
+
+	memberNames: string[]; // Usernames
+
+	groupId: number;
+}
+
+export interface ChangeEventMembersResponse {
+	success: boolean;
+	message: string;
+}
+
+// --------------------------------------------------------------------------------------


### PR DESCRIPTION
Three main things here:
1) Made creating an Event a bit safer- now each member assigned to the event is validated to make sure it exists and is in the group the event is tied to
2) Added an endpoint to alter the group members who are assigned to an event
3) Created an EventOccurrence model and added repeatEvery field to API Endpoint. This is not functional yet, it is not as trivial as I thought to have an Event basically spawn an EventOccurrence object and even less clear how to handle creating multiple of these. Regardless, the model is here for now