### PR TITLE
Bugfix: No group members specified for event

### DIFF
--- a/backend/chore_tracker/views.py
+++ b/backend/chore_tracker/views.py
@@ -267,6 +267,9 @@ class CreateEvent(APIView):
             print(memberNames)
 
             for username in memberNames:
+                if username == '' and len(memberNames) == 1:
+                    event.members.set(group_members)
+                    break
                 try:
                     user = User.objects.get(username=username)
 


### PR DESCRIPTION
Found a bug from the latest changes where if no group members are specified to be assigned to an event, we get an error

This is a quick fix. Right now, the frontend is sending a list with a single empty string as the group members to assign. Maybe this is okay but we should talk about how we want to handle it.